### PR TITLE
Improve Descartes-Teams ChatGPT connector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copia este archivo a .env y completa tus credenciales
+OPENAI_API_KEY=
+TEAMS_WEBHOOK_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Environment variables
+.env
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# ex
+# Conector Descartes a ChatGPT Teams
+
+Este repositorio contiene un ejemplo sencillo (MCP) para conectar el sistema **Descartes** con un conector de ChatGPT en Microsoft Teams.
+
+## Requisitos
+
+- Python 3.8+
+- Las dependencias listadas en `requirements.txt`
+- Variables de entorno:
+  - `OPENAI_API_KEY` con la clave de acceso a OpenAI
+  - `TEAMS_WEBHOOK_URL` con la URL del webhook entrante de Teams
+
+## Uso
+
+1. Instalar las dependencias:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Copiar `.env.example` a `.env` y completar tus credenciales:
+   ```bash
+   cp .env.example .env
+   # editar .env con OPENAI_API_KEY y TEAMS_WEBHOOK_URL
+   ```
+3. Ejecutar el conector:
+   ```bash
+   python descartes_teams_connector.py
+   ```
+
+El script recupera información simulada de Descartes, genera un resumen con ChatGPT y lo publica en el canal de Teams configurado.

--- a/descartes_teams_connector.py
+++ b/descartes_teams_connector.py
@@ -1,0 +1,49 @@
+import os
+import requests
+import openai
+from dotenv import load_dotenv
+
+load_dotenv()
+
+OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
+TEAMS_WEBHOOK_URL = os.getenv('TEAMS_WEBHOOK_URL')
+
+
+def get_descartes_update():
+    """Simulate retrieval of an update from Descartes system."""
+    # Placeholder: in a real scenario, fetch data from Descartes API or database
+    return "Estado de envío actualizado en Descartes"
+
+
+def ask_chatgpt(prompt: str) -> str:
+    """Send a prompt to OpenAI's ChatGPT API and return the response text."""
+    if not OPENAI_API_KEY:
+        raise ValueError("OPENAI_API_KEY environment variable not set")
+
+    openai.api_key = OPENAI_API_KEY
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message.content.strip()
+
+
+def send_to_teams(message: str):
+    """Post a message to Microsoft Teams using an incoming webhook."""
+    if not TEAMS_WEBHOOK_URL:
+        raise ValueError("TEAMS_WEBHOOK_URL environment variable not set")
+
+    payload = {"text": message}
+    resp = requests.post(TEAMS_WEBHOOK_URL, json=payload)
+    resp.raise_for_status()
+
+
+def main():
+    desc = get_descartes_update()
+    prompt = f"Genera un breve resumen para Teams basado en: {desc}"
+    gpt_response = ask_chatgpt(prompt)
+    send_to_teams(gpt_response)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openai
+requests
+python-dotenv


### PR DESCRIPTION
## Summary
- add sample `.env` file and ignore `.env`
- document credentials setup in README
- load variables from `.env` via `python-dotenv`
- list `python-dotenv` in requirements

## Testing
- `python -m py_compile descartes_teams_connector.py`


------
https://chatgpt.com/codex/tasks/task_b_6849e940d72083329b7ef899356ed6f1