### PR TITLE
Add workflow for GitHub Actions

### DIFF
--- a/.github/workflows/run-connector.yml
+++ b/.github/workflows/run-connector.yml
@@ -1,0 +1,23 @@
+name: Run Descartes Connector
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run connector
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
+        run: python descartes_teams_connector.py

--- a/README.md
+++ b/README.md
@@ -27,3 +27,11 @@ Este repositorio contiene un ejemplo sencillo (MCP) para conectar el sistema **D
    ```
 
 El script recupera información simulada de Descartes, genera un resumen con ChatGPT y lo publica en el canal de Teams configurado.
+
+## Uso con GitHub Actions
+Este repositorio incluye un *workflow* que te permite ejecutar el conector directamente desde GitHub. Para activarlo:
+
+1. Define los secretos `OPENAI_API_KEY` y `TEAMS_WEBHOOK_URL` en la configuración de tu repositorio.
+2. El workflow `Run Descartes Connector` se puede lanzar manualmente desde la pestaña **Actions** o dejar programado para que se ejecute cada hora.
+
+Cuando se ejecute, GitHub Actions instalará las dependencias y ejecutará `descartes_teams_connector.py` enviando el resumen a Teams.

--- a/README.md
+++ b/README.md
@@ -35,3 +35,5 @@ Este repositorio incluye un *workflow* que te permite ejecutar el conector direc
 2. El workflow `Run Descartes Connector` se puede lanzar manualmente desde la pestaña **Actions** o dejar programado para que se ejecute cada hora.
 
 Cuando se ejecute, GitHub Actions instalará las dependencias y ejecutará `descartes_teams_connector.py` enviando el resumen a Teams.
+
+Si necesitas modificar la frecuencia de ejecución, ajusta la expresión `cron` en `.github/workflows/run-connector.yml`.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run the connector on schedule or manually
- update README with instructions to use the workflow

## Testing
- `python descartes_teams_connector.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_6849fa45d6e08332b95fa8c374cdeea0